### PR TITLE
fix: run framework ready effect only once

### DIFF
--- a/project/hooks/useFrameworkReady.ts
+++ b/project/hooks/useFrameworkReady.ts
@@ -9,5 +9,5 @@ declare global {
 export function useFrameworkReady() {
   useEffect(() => {
     window.frameworkReady?.();
-  });
+  }, []);
 }


### PR DESCRIPTION
## Summary
- ensure `useFrameworkReady`'s effect only runs once on mount by adding an empty dependency array

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68ac7a85730c8331a5588526f3870ae8