### PR TITLE
Fix font weight value in not found screen

### DIFF
--- a/project/app/+not-found.tsx
+++ b/project/app/+not-found.tsx
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
-    fontWeight: 600,
+    fontWeight: '600',
   },
   link: {
     marginTop: 15,


### PR DESCRIPTION
## Summary
- fix fontWeight syntax in not found screen styles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: expo: not found)


------
https://chatgpt.com/codex/tasks/task_b_68ac84eaa2f08331be9db289f7fbb40f