### PR TITLE
Validate price filters in search

### DIFF
--- a/project/app/(tabs)/recherche.tsx
+++ b/project/app/(tabs)/recherche.tsx
@@ -83,11 +83,11 @@ export default function RechercheScreen() {
       filtered = filtered.filter(article => article.sexe === filters.sexe);
     }
 
-    if (filters.prixMin) {
+    if (filters.prixMin !== '' && !isNaN(parseFloat(filters.prixMin))) {
       filtered = filtered.filter(article => article.prix >= parseFloat(filters.prixMin));
     }
 
-    if (filters.prixMax) {
+    if (filters.prixMax !== '' && !isNaN(parseFloat(filters.prixMax))) {
       filtered = filtered.filter(article => article.prix <= parseFloat(filters.prixMax));
     }
 


### PR DESCRIPTION
## Summary
- validate minimum and maximum price filters to ensure numeric values before applying

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: fetch failed during Expo lint)

------
https://chatgpt.com/codex/tasks/task_b_68ac8f9354348331a13f41ba8df2803a